### PR TITLE
Revert "Uncomment message"

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,3 @@
 spring.application.name=sb-rest-configmap
 
-message=Hello, %s
+#message=Hello, %s


### PR DESCRIPTION
Reverts obsidian-toaster-quickstarts/rest_configmap_springboot-tomcat#4

@VeerMuchandi

The application.properties should not contain the message key, otherwise when we will deploy the application on openshift, then the key will not be overriden by the key coming from the config map.

I suggest that we copy/paste the application.properties file from another location to src/main/resources when we launch locally spring-boot (mvn install or mvn spring-boot:run) and copy/paste another file where the key is not defined when the project is packaged/deployed on openshift.