### PR TITLE
Force validation of message property in Spring Context startup

### DIFF
--- a/greeting-service/src/main/java/io/openshift/booster/service/GreetingController.java
+++ b/greeting-service/src/main/java/io/openshift/booster/service/GreetingController.java
@@ -16,8 +16,6 @@
  */
 package io.openshift.booster.service;
 
-import java.util.Objects;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -35,8 +33,6 @@ public class GreetingController {
 
     @RequestMapping("/api/greeting")
     public Greeting greeting(@RequestParam(value = "name", defaultValue = "World") String name) {
-        Objects.requireNonNull(properties.getMessage(), "Greeting message was not set in the properties");
-
         String message = String.format(properties.getMessage(), name);
         return new Greeting(message);
     }

--- a/greeting-service/src/main/java/io/openshift/booster/service/GreetingProperties.java
+++ b/greeting-service/src/main/java/io/openshift/booster/service/GreetingProperties.java
@@ -18,16 +18,21 @@ package io.openshift.booster.service;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotNull;
 
 @Component
 @ConfigurationProperties("greeting")
+@Validated
 public class GreetingProperties {
 
     /**
      * This message has to be set in the application.properties file. If application is executed locally, "local" profile is
      * expected. On OpenShift, this property is set by a ConfigMap.
      */
-    private String message = null;
+    @NotNull(message = "Greeting message was not set in the properties")
+    private String message;
 
     public String getMessage() {
         return message;


### PR DESCRIPTION
This change makes a potential absence of the message property visible
immediately upon the application startup instead of having to wait to
perform the appropriate REST call