### PR TITLE
Downgrade to booster parent 1.5.10-9-rhoar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,11 +20,11 @@
   <parent>
     <groupId>io.openshift.booster</groupId>
     <artifactId>spring-boot-booster-parent</artifactId>
-    <version>1.5.12-3-rhoar</version>
+    <version>1.5.10-9-rhoar</version>
   </parent>
 
   <artifactId>spring-boot-configmap</artifactId>
-  <version>1.5.12-1-osio-SNAPSHOT</version>
+  <version>1.5.10-1-osio-SNAPSHOT</version>
 
   <name>Spring Boot - ConfigMap Booster</name>
   <description>Spring Boot - ConfigMap Booster</description>


### PR DESCRIPTION
I propose to downgrade to the parent which uses spring-boot-bom which is available, at least until the uncertainty with the new releases is resolved. This would give us a working version for the summit and OSIO. If we get a new release before then, we can always revert. 
Same should be done for all redhat branches as well IMO.