### PR TITLE
chore: adapt to springboot 2.4.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <arquillian.version>1.4.0.Final</arquillian.version>
     <arquillian-cube.version>1.18.2</arquillian-cube.version>
+    <junit.version>4.13.2</junit.version>
     <ubi.version>1.3</ubi.version>
     <openshift-client.version>3.1.8</openshift-client.version>
     <spring-boot.version>2.4.9</spring-boot.version>
@@ -100,7 +101,7 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-starter-kubernetes-config</artifactId>
+      <artifactId>spring-cloud-starter-kubernetes-fabric8-config</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -141,6 +142,12 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
1. reverted junit to v4
1. replaced spring-cloud-starter-kubernetes-config with spring-cloud-starter-kubernetes-fabric8-config