### PR TITLE
bump dekorate 2.11.5 and removed default maven settings on dekorate OCP

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build Project using Dekorate
         run: |
           oc new-project dekorate
-          ./run_tests_with_dekorate_in_ocp.sh
+          ./run_tests_with_dekorate_in_ocp.sh -s .github/mvn-settings.xml
       - name: Delete Project using Dekorate
         run: oc delete project dekorate
       - name: Clean folder

--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ helm uninstall configmap
 ./run_tests_with_dekorate_in_ocp.sh
 ```
 
+Alternatively, tests can be executed against a specific Spring Boot or Dekorate version by passing the
+version as a `-D<variable property name>=value` parameter. For instance overriding both the Spring Boot and the Dekorate versions using their corresponding version properties is done the following way:
+
+```bash
+./run_tests_with_dekorate_in_ocp.sh -Dspring-boot.version=2.7.3 -Ddekorate.version=2.11.1
+```
+
 ## Running Tests on OpenShift using S2i from Source
 
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <!-- We cannot use Dekorate 3.x because it uses Fabric8 Kubernetes Client 6.x which is incompatible with
     https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-kubernetes-fabric8-autoconfig that uses the
     version 5.10.2. Once this dependency bumped to the latest 6.x, we can bump Dekorate to 3.x. -->
-    <dekorate.version>2.11.4</dekorate.version>
+    <dekorate.version>2.11.5</dekorate.version>
 
     <!-- Overriden from Spring Boot -->
     <tomcat.version>9.0.65</tomcat.version>

--- a/run_tests_with_dekorate_in_ocp.sh
+++ b/run_tests_with_dekorate_in_ocp.sh
@@ -3,4 +3,4 @@
 oc create -f .openshiftio/resource.configmap.yaml
 
 # Run Tests
-./mvnw -s .github/mvn-settings.xml clean verify -Popenshift,openshift-it
+eval "./mvnw clean verify -Popenshift,openshift-it $@"


### PR DESCRIPTION
* bump dekorate 2.11.5
* removed Maven Settings from defaulting on the `run_tests_with_dekorate_in_ocp.sh` script

`Automated from ansible update-examples-upstream-versions-playbook`